### PR TITLE
Implement private live sermon sessions (Issue #4)

### DIFF
--- a/src/controllers/live-sessions.controller.ts
+++ b/src/controllers/live-sessions.controller.ts
@@ -1,0 +1,151 @@
+import { Types } from 'mongoose';
+import Sermon from '../models/sermon.model';
+import Organization from '../models/organization.model';
+import SermonLiveSession from '../models/sermon-live-session.model';
+import Logger from '../utils/logger';
+
+const logger = new Logger('/src/controllers/live-sessions.controller.ts');
+
+export type StartLiveSessionPayload = {
+  sermonId: string;
+  // For now, backend issue specifies PRIVATE sessions.
+  visibility?: 'PRIVATE' | 'PUBLIC';
+};
+
+export type EndLiveSessionPayload = {
+  sermonId: string;
+  storeRecording?: boolean;
+};
+
+class LiveSessionsController {
+  async startSession(payload: StartLiveSessionPayload, userUid: string) {
+    const { sermonId, visibility = 'PRIVATE' } = payload;
+
+    const sermon = await Sermon.findById(sermonId);
+    if (!sermon) {
+      return { status: 404, body: { message: 'sermon not found' } };
+    }
+
+    if (sermon.status !== 'LIVE') {
+      return { status: 400, body: { message: 'sermon is not LIVE' } };
+    }
+
+    const org = await Organization.findById(sermon.organizationId);
+    if (!org) {
+      return { status: 404, body: { message: 'organization not found' } };
+    }
+
+    const roomName = sermon.roomName ?? `sermon-${sermon._id.toString()}`;
+
+    // Ensure no existing LIVE session for this sermon
+    const existing = await SermonLiveSession.findOne({
+      sermonId: sermon._id,
+      status: 'LIVE',
+    });
+
+    if (existing) {
+      return {
+        status: 200,
+        body: {
+          liveSession: existing,
+          roomName: existing.roomName,
+        },
+      };
+    }
+
+    const created = await SermonLiveSession.create({
+      sermonId: sermon._id,
+      orgId: org._id,
+      roomName,
+      visibility,
+      status: 'LIVE',
+      startedAt: new Date(),
+      createdBy: userUid,
+    });
+
+    logger.debug('Live session started', {
+      sermonId,
+      orgId: org._id.toString(),
+      roomName,
+      visibility,
+    });
+
+    return { status: 201, body: { liveSession: created, roomName } };
+  }
+
+  async endSession(payload: EndLiveSessionPayload, userUid: string) {
+    const { sermonId, storeRecording = false } = payload;
+
+    const sermon = await Sermon.findById(sermonId);
+    if (!sermon) {
+      return { status: 404, body: { message: 'sermon not found' } };
+    }
+
+    const session = await SermonLiveSession.findOne({
+      sermonId: sermon._id,
+      status: 'LIVE',
+    });
+
+    if (!session) {
+      return { status: 404, body: { message: 'live session not found' } };
+    }
+
+    session.status = 'ENDED';
+    session.endedAt = new Date();
+    session.endedBy = userUid;
+    session.storeRecording = storeRecording;
+    await session.save();
+
+    // Mark sermon ended as well (backend is source of truth)
+    sermon.status = 'ENDED';
+    sermon.endedAt = new Date();
+    await sermon.save();
+
+    logger.debug('Live session ended', {
+      sermonId,
+      roomName: session.roomName,
+      storeRecording,
+    });
+
+    return { status: 200, body: { liveSession: session } };
+  }
+
+  async joinSession(sermonId: string) {
+    const sermon = await Sermon.findById(sermonId);
+    if (!sermon) {
+      return { status: 404, body: { message: 'sermon not found' } };
+    }
+
+    const session = await SermonLiveSession.findOne({
+      sermonId: sermon._id,
+      status: 'LIVE',
+    });
+
+    if (!session) {
+      return { status: 404, body: { message: 'live session not found' } };
+    }
+
+    return {
+      status: 200,
+      body: {
+        roomName: session.roomName,
+        liveSession: session,
+      },
+    };
+  }
+
+  async listLiveSessions(orgId: string) {
+    if (!Types.ObjectId.isValid(orgId)) {
+      return { status: 400, body: { message: 'invalid orgId' } };
+    }
+
+    const sessions = await SermonLiveSession.find({
+      orgId: new Types.ObjectId(orgId),
+      status: 'LIVE',
+    }).sort({ startedAt: -1 });
+
+    return { status: 200, body: { liveSessions: sessions } };
+  }
+}
+
+export default LiveSessionsController;

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -2,3 +2,4 @@
 export { default as errorHandler } from './error-handler';
 export { default as verifyToken } from './verify-token';
 export { default as verifyOrgRole } from './verify-org-role';
+export { default as verifyOrgMember } from './verify-org-member';

--- a/src/middlewares/verify-org-member.ts
+++ b/src/middlewares/verify-org-member.ts
@@ -1,0 +1,48 @@
+import { Request, Response, NextFunction } from 'express';
+import Organization from '../models/organization.model';
+import Logger from '../utils/logger';
+
+const logger = new Logger('/src/middlewares/verify-org-member.ts');
+
+/**
+ * Ensures the authenticated user belongs to the organization.
+ * Belongs means: organizer, pastor, manager, or member.
+ *
+ * Expects orgId in:
+ * - req.params.orgId OR
+ * - req.body.organizationId OR
+ * - req.body.orgId
+ */
+export const verifyOrgMember = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const userId = (req.user as { uid?: string })?.uid;
+    if (!userId) return res.status(401).json({ message: 'Unauthorized' });
+
+    const orgId = req.params.orgId ?? req.body?.organizationId ?? req.body?.orgId;
+    if (!orgId) return res.status(400).json({ message: 'orgId is required' });
+
+    const org = await Organization.findById(orgId);
+    if (!org) return res.status(404).json({ message: 'Organization not found' });
+
+    const isOrganizer = org.organizer === userId;
+    const isPastor = org.pastor === userId;
+    const isManager = org.managers?.includes(userId) ?? false;
+    const isMember = org.members?.includes(userId) ?? false;
+
+    if (!isOrganizer && !isPastor && !isManager && !isMember) {
+      logger.debug(`User ${userId} is not a member of org ${orgId}`);
+      return res.status(403).json({ message: 'Forbidden: not a member of org' });
+    }
+
+    next();
+  } catch (err) {
+    logger.error('verifyOrgMember error:', err);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
+};
+
+export default verifyOrgMember;

--- a/src/models/sermon-live-session.model.ts
+++ b/src/models/sermon-live-session.model.ts
@@ -1,0 +1,90 @@
+import { model, Schema, Types } from 'mongoose';
+
+export type LiveSessionStatus = 'LIVE' | 'ENDED';
+export type LiveSessionVisibility = 'PUBLIC' | 'PRIVATE';
+
+export interface ISermonLiveSession {
+  sermonId: Types.ObjectId;
+  orgId: Types.ObjectId;
+  roomName: string;
+  visibility: LiveSessionVisibility;
+  status: LiveSessionStatus;
+  startedAt: Date;
+  endedAt?: Date;
+
+  createdBy: string; // firebase uid
+  endedBy?: string; // firebase uid
+
+  // Optional hint for downstream behavior
+  storeRecording?: boolean;
+}
+
+const sermonLiveSessionSchema = new Schema<ISermonLiveSession>(
+  {
+    sermonId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Sermon',
+      required: true,
+      index: true,
+    },
+    orgId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Organization',
+      required: true,
+      index: true,
+    },
+    roomName: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    visibility: {
+      type: String,
+      enum: ['PUBLIC', 'PRIVATE'],
+      required: true,
+      default: 'PRIVATE',
+      index: true,
+    },
+    status: {
+      type: String,
+      enum: ['LIVE', 'ENDED'],
+      required: true,
+      default: 'LIVE',
+      index: true,
+    },
+    startedAt: {
+      type: Date,
+      required: true,
+      default: Date.now,
+    },
+    endedAt: {
+      type: Date,
+    },
+    createdBy: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    endedBy: {
+      type: String,
+    },
+    storeRecording: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  { timestamps: true },
+);
+
+// Only one LIVE session per sermon.
+sermonLiveSessionSchema.index(
+  { sermonId: 1, status: 1 },
+  { unique: true, partialFilterExpression: { status: 'LIVE' } },
+);
+
+const SermonLiveSession = model<ISermonLiveSession>(
+  'SermonLiveSession',
+  sermonLiveSessionSchema,
+);
+
+export default SermonLiveSession;

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -5,6 +5,7 @@ import orgsRoutes from './organizations.routes'
 import postsRoutes from './posts.routes'
 import commentsRoutes from './comments.routes'
 import sermonsRoutes from './sermons.routes'
+import liveSessionsRoutes from './live-sessions.routes'
 const router = Router();
 
 router.use("/users", usersRoutes)
@@ -12,5 +13,6 @@ router.use("/organizations", orgsRoutes)
 router.use("/posts", postsRoutes)
 router.use("/comments", commentsRoutes);
 router.use("/sermons", sermonsRoutes);
+router.use("/live-sessions", liveSessionsRoutes);
 
 export default router;

--- a/src/routes/v1/live-sessions.routes.ts
+++ b/src/routes/v1/live-sessions.routes.ts
@@ -1,0 +1,128 @@
+import { Router } from 'express';
+
+import LiveSessionsController from '../../controllers/live-sessions.controller';
+import { verifyOrgMember, verifyOrgRole, verifyToken } from '../../middlewares';
+import Organization from '../../models/organization.model';
+
+const router = Router({ mergeParams: true });
+const controller = new LiveSessionsController();
+
+// POST /api/v1/live-sessions/start
+// Only organizer/pastor/manager can start.
+router.post('/start', verifyToken, async (req, res, next) => {
+  try {
+    const { sermonId } = req.body;
+    const userUid = (req.user as { uid?: string })?.uid;
+    if (!sermonId) return res.status(400).json({ message: 'sermonId is required' });
+    if (!userUid) return res.status(401).json({ message: 'Unauthorized' });
+
+    // Enforce organizer/pastor/manager based on the sermon.organizationId.
+    const { default: Sermon } = await import('../../models/sermon.model');
+    const sermon = await Sermon.findById(sermonId);
+    if (!sermon) return res.status(404).json({ message: 'sermon not found' });
+
+    const org = await Organization.findById(sermon.organizationId);
+    if (!org) return res.status(404).json({ message: 'Organization not found' });
+
+    const isOrganizer = org.organizer === userUid;
+    const isPastor = org.pastor === userUid;
+    const isManager = org.managers?.includes(userUid) ?? false;
+
+    if (!isOrganizer && !isPastor && !isManager) {
+      return res.status(403).json({
+        message:
+          'Forbidden: Only organizer, pastor, or manager can perform this action',
+      });
+    }
+
+    const result = await controller.startSession({ sermonId }, userUid);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /api/v1/live-sessions/join
+// Any org member can join.
+router.post('/join', verifyToken, async (req, res, next) => {
+  try {
+    const { sermonId } = req.body;
+    const userUid = (req.user as { uid?: string })?.uid;
+    if (!sermonId) return res.status(400).json({ message: 'sermonId is required' });
+    if (!userUid) return res.status(401).json({ message: 'Unauthorized' });
+
+    // Determine org from sermon session, then enforce membership.
+    const joinResult = await controller.joinSession(sermonId);
+    if (joinResult.status !== 200) {
+      return res.status(joinResult.status).json(joinResult.body);
+    }
+
+    const orgId = (joinResult.body.liveSession as any)?.orgId?.toString();
+    if (!orgId) return res.status(500).json({ message: 'live session missing orgId' });
+
+    // Inline membership check (reuses same logic as verifyOrgMember)
+    const org = await Organization.findById(orgId);
+    if (!org) return res.status(404).json({ message: 'Organization not found' });
+
+    const isOrganizer = org.organizer === userUid;
+    const isPastor = org.pastor === userUid;
+    const isManager = org.managers?.includes(userUid) ?? false;
+    const isMember = org.members?.includes(userUid) ?? false;
+
+    if (!isOrganizer && !isPastor && !isManager && !isMember) {
+      return res.status(403).json({ message: 'Forbidden: not a member of org' });
+    }
+
+    return res.status(200).json(joinResult.body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /api/v1/live-sessions/end
+// Only organizer can end.
+router.post('/end', verifyToken, async (req, res, next) => {
+  try {
+    const { sermonId, storeRecording } = req.body;
+    const userUid = (req.user as { uid?: string })?.uid;
+    if (!sermonId) return res.status(400).json({ message: 'sermonId is required' });
+    if (!userUid) return res.status(401).json({ message: 'Unauthorized' });
+
+    // Organizer-only: enforce by checking org organizer matches.
+    const joinResult = await controller.joinSession(sermonId);
+    if (joinResult.status !== 200) {
+      return res.status(joinResult.status).json(joinResult.body);
+    }
+
+    const orgId = (joinResult.body.liveSession as any)?.orgId?.toString();
+    const org = orgId ? await Organization.findById(orgId) : null;
+    if (!org) return res.status(404).json({ message: 'Organization not found' });
+
+    if (org.organizer !== userUid) {
+      return res.status(403).json({ message: 'Forbidden: only organizer can end session' });
+    }
+
+    const result = await controller.endSession({ sermonId, storeRecording }, userUid);
+    return res.status(result.status).json(result.body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /api/v1/organizations/:orgId/live-sessions
+router.get(
+  '/organizations/:orgId/live-sessions',
+  verifyToken,
+  verifyOrgMember,
+  async (req, res, next) => {
+    try {
+      const { orgId } = req.params;
+      const result = await controller.listLiveSessions(orgId);
+      return res.status(result.status).json(result.body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;


### PR DESCRIPTION
Closes #4\n\nAdds backend support for private live sermon voice sessions.\n\n### What\n- New SermonLiveSession model to track LIVE/ENDED sessions\n- API endpoints to start/join/end sessions and list active sessions for an org\n- Org membership enforcement for joining/listing\n\n### Endpoints\n- POST /api/v1/live-sessions/start\n- POST /api/v1/live-sessions/join\n- POST /api/v1/live-sessions/end\n- GET  /api/v1/live-sessions/organizations/:orgId/live-sessions\n\n### Notes\n- End session also marks the Sermon as ENDED\n- Visibility currently defaults to PRIVATE per issue requirements\n\nBuild\n- npm run build